### PR TITLE
Add support for sub-tasks and issue-links

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ var jiraHtmlToMarkdown      = require('./jim-jira').jiraHtmlToMarkdown;
 var jiraGetProjectList      = require('./jim-jira').jiraGetProjectList;
 
 var toString                = require('./jim-strings').toString;
+var splitID                 = require('./jim-strings').splitID;
 
 var createIssueIfAbsent     = require('./jim-github').createIssueIfAbsent;
 var createLabel             = require('./jim-github').createLabel;
@@ -76,7 +77,8 @@ app.post('/migrate', function (req, res) {
     var defaultusername = req.body.defaultusername;
     var token           = req.body.token;
 
-    var url = "https://java.net/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?jqlQuery=project+%3D+" + project + "&tempMax=1000";
+    // var url = "https://java.net/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?jqlQuery=project+%3D+" + project + "&tempMax=1000";
+    var url = "https://java.net/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?jqlQuery=project+%3D+" + project + "+AND+issue+%3D+GLASSFISH-21430&tempMax=1000";
 
     console.log("Requested Migration of Project [" + project + "] from [" + url + "]");
 
@@ -168,8 +170,7 @@ app.post('/migrate', function (req, res) {
 
                 // determine the JIRA Project and Issue ID
                 var key = xmlItem.childNamed("key").val;
-                issue.project = key.replace(/(.*)-(.*)/g, "$1");
-                issue.id = key.replace(/(.*)-(.*)/g, "$2");
+                [issue.project, issue.id] = splitID(key);
 
                 issue.title = xmlItem.childNamed("summary").val;
                 issue.body = jiraHtmlToMarkdown(xmlItem.childNamed("description").val, issue.project).trim();
@@ -250,6 +251,73 @@ app.post('/migrate', function (req, res) {
                             body: body
                         });
                     })
+                }
+
+                tmp_project = ""
+                tmp_id = ""
+                // ----- extract all sub-tasks and add as comments -----
+                subtasks = [];
+                childValuesFrom(xmlItem.childNamed("subtasks"), "subtask", subtasks)
+                tmp_body = "Sub-Tasks:\n";
+                for (var i = 0; i < subtasks.length; i++) {
+                    [tmp_project, tmp_id] = splitID(subtasks[i]);
+                    tmp_url = "https://github.com/" + username + "/" + tmp_project.toLowerCase() + "/issues/" + tmp_id;
+                    tmp_body += "[" + subtasks[i] + "](" + tmp_url + ")\n";
+                }
+                if(subtasks.length != 0) {
+                    comments.push({
+                        created_at: issue.created_at,
+                        body: tmp_body
+                    });
+                }
+
+                // ----- extract the parent task and add as comment -----
+                var parent = xmlItem.childNamed("parent")
+
+                if(parent) {
+                    tmp_body = "Parent-Task: ";
+                    [tmp_project, tmp_id] = splitID(parent.val);
+                    tmp_url = "https://github.com/" + username + "/" + tmp_project.toLowerCase() + "/issues/" + tmp_id;
+                    tmp_body += "[" + parent.val + "](" + tmp_url + ")\n";
+                    comments.push({
+                        created_at: issue.created_at,
+                        body: tmp_body
+                    });
+                }
+
+                // ----- extract all issue-links and add as comments -----
+                var xmlLinks = xmlItem.childNamed("issuelinks")
+                tmp_body = "Issue-Links:\n"
+                if(xmlLinks) {
+                    xmlLinks = xmlLinks.childrenNamed("issuelinktype");
+                    if(xmlLinks) {
+                        xmlLinks.forEach(function(xmlLink) {
+                            var outwardLinks = xmlLink.childNamed("outwardlinks");
+                            var inwardLinks = xmlLink.childNamed("inwardlinks");
+                            if(outwardLinks) {
+                                tmp_body += outwardLinks.attr.description + "\n";
+                                outwardLinks.childrenNamed('issuelink').forEach(function(issuelink){
+                                    tmp_key = issuelink.valueWithPath('issuekey');
+                                    [tmp_project, tmp_id] = splitID(tmp_key);
+                                    tmp_url = "https://github.com/" + username + "/" + tmp_project.toLowerCase() + "/issues/" + tmp_id;
+                                    tmp_body += "[" + tmp_key + "](" + tmp_url + ")\n";
+                                });
+                            }
+                            if(inwardLinks) {
+                                tmp_body += inwardLinks.attr.description + "\n";
+                                inwardLinks.childrenNamed('issuelink').forEach(function(issuelink){
+                                    tmp_key = issuelink.valueWithPath('issuekey');
+                                    [tmp_project, tmp_id] = splitID(tmp_key);
+                                    tmp_url = "https://github.com/" + username + "/" + tmp_project.toLowerCase() + "/issues/" + tmp_id;
+                                    tmp_body += "[" + tmp_key + "](" + tmp_url + ")\n";
+                                });
+                            }
+                        })
+                        comments.push({
+                            created_at: issue.created_at,
+                            body: tmp_body
+                        });
+                    }
                 }
 
                 issues.push({"issue": issue, "comments": comments});

--- a/app.js
+++ b/app.js
@@ -77,8 +77,7 @@ app.post('/migrate', function (req, res) {
     var defaultusername = req.body.defaultusername;
     var token           = req.body.token;
 
-    // var url = "https://java.net/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?jqlQuery=project+%3D+" + project + "&tempMax=1000";
-    var url = "https://java.net/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?jqlQuery=project+%3D+" + project + "+AND+issue+%3D+GLASSFISH-21430&tempMax=1000";
+    var url = "https://java.net/jira/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?jqlQuery=project+%3D+" + project + "&tempMax=1000";
 
     console.log("Requested Migration of Project [" + project + "] from [" + url + "]");
 

--- a/jim-strings.js
+++ b/jim-strings.js
@@ -26,4 +26,12 @@ function toString(collection)
     }
 };
 
+function splitID(issueID)
+{
+    var project = issueID.replace(/(.*)-(.*)/g, "$1");
+    var id = issueID.replace(/(.*)-(.*)/g, "$2");
+    return [project, id]
+}
+
 exports.toString = toString;
+exports.splitID = splitID;


### PR DESCRIPTION
This PR is for #6. Support for the following included: 
1. Sub-task and parent task
2. Issue Links - Inward and Outward

Eg.,
```
Sub-Tasks:
[GLASSFISH-21480](https://github.com/mskd12/glassfish/issues/21480)
[GLASSFISH-21481](https://github.com/mskd12/glassfish/issues/21481)
[GLASSFISH-21487](https://github.com/mskd12/glassfish/issues/21487)
[XXX-YYY](https://github.com/{repo_author}/XXX/issues/YYY)
```
Have a look at [this](https://github.com/mskd12/glassfish1/issues/150) for an example of how links are managed